### PR TITLE
Use env to locate python binary

### DIFF
--- a/git-bzr
+++ b/git-bzr
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # git-cl -- a git-command for integrating reviews on Rietveld
 # Copyright (C) 2008 Evan Martin <martine@danga.com>
 # Copyright (C) 2010 Andy Smith <andy@term.ie>


### PR DESCRIPTION
FreeBSD, for example, installs in `/usr/local/bin/python`
