### PR TITLE
fix clone for urls ending in '/'

### DIFF
--- a/git-bzr
+++ b/git-bzr
@@ -388,7 +388,7 @@ def cmd_clone(args):
   url = args[0]
 
   if len(args) == 1:
-    target = url.rpartition(':')[2].rpartition('/')[2]
+    target = url.rpartition(':')[2].rstrip('/').rpartition('/')[2]
   else:
     target = args[1]
 


### PR DESCRIPTION
if no second argument is supplied, `git bzr clone url` tries to clone into the current working directory, if url ends in a forward slash.
