### PR TITLE
git-bzr do not support using "/" in branch name.

### DIFF
--- a/git-bzr
+++ b/git-bzr
@@ -579,6 +579,10 @@ def cmd_import(args):
   if branch_exists(bzr_ref):
     die('Branch already exists: %s', bzr_ref)
 
+  # Permit git-style branch name with / in them
+  if not os.path.isdir(os.path.dirname(cl.bzr_dir(branch))):
+    os.makedirs(os.path.dirname(cl.bzr_dir(branch)))
+
   # Do the actual bzr fetch
   bzr(['branch', url, cl.bzr_dir(branch)])
 


### PR DESCRIPTION
- git-bzr (cmd_import): Create parent directories of the bzr branch.

This pull request fixes #33
